### PR TITLE
Persist data when container restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV ARCH_FILENAME=""
 
 #  Set ARCH_FILENAME based on TARGETARCH as "aarch64" is used instead of "arm64" in the filename
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        ARCH_FILENAME="amd64"; \
+    ARCH_FILENAME="amd64"; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        ARCH_FILENAME="aarch64"; \
+    ARCH_FILENAME="aarch64"; \
     else \
-        echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    echo "Unsupported architecture: $TARGETARCH" && exit 1; \
     fi && \
     mkdir /opt/ZenithProxy && \
     apt-get update && apt-get install -y wget unzip && \
@@ -20,4 +20,5 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 
 EXPOSE 25565
 WORKDIR /opt/ZenithProxy
+VOLUME /opt/ZenithProxy
 CMD ./launch --unattended

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: ghcr.io/rfresh2/zenithproxy:latest
     ports:
       - '25565:25565'
+    volumes:
+      - zenithdata:/opt/ZenithProxy
     environment:
 #     Discord setup guide: https://wiki.2b2t.vc/Discord-Bot-Guide/
       ZENITH_DISCORD_TOKEN: editme
@@ -18,3 +20,6 @@ services:
 #         equivalent command: https://wiki.2b2t.vc/Commands/#serverconnection
     stdin_open: true
     tty: true
+
+volumes:
+  zenithdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     image: ghcr.io/rfresh2/zenithproxy:latest
     ports:
       - '25565:25565'
-    volumes:
-      - zenithdata:/opt/ZenithProxy
     environment:
 #     Discord setup guide: https://wiki.2b2t.vc/Discord-Bot-Guide/
       ZENITH_DISCORD_TOKEN: editme
@@ -20,6 +18,3 @@ services:
 #         equivalent command: https://wiki.2b2t.vc/Commands/#serverconnection
     stdin_open: true
     tty: true
-
-volumes:
-  zenithdata:


### PR DESCRIPTION
Currently, if the container restarts all configuration data is lost. This fixes that by creating a volume to persist data in the /opt/ZenithProxy directory.